### PR TITLE
Transformpipe: Support default value

### DIFF
--- a/packages/common/src/pipe/transform.pipe.ts
+++ b/packages/common/src/pipe/transform.pipe.ts
@@ -19,21 +19,22 @@ export class TransformPipe implements DiscordPipeTransform {
   ): any {
     if (!metadata.metatype || !interaction || !interaction.isCommand()) return;
 
-    const { dtoInstance } = metadata.commandNode;
+    const { dtoInstance: originalInstance } = metadata.commandNode;
+    const newInstance = Object.assign({}, originalInstance);
 
-    Object.keys(dtoInstance).forEach((property: string) => {
+    Object.keys(originalInstance).forEach((property: string) => {
       const paramDecoratorMetadata =
-        this.metadataProvider.getParamDecoratorMetadata(dtoInstance, property);
+        this.metadataProvider.getParamDecoratorMetadata(originalInstance, property);
 
       if (!paramDecoratorMetadata) return;
 
       const { name, required } = paramDecoratorMetadata;
-      dtoInstance[property] = interaction.options.get(
-        name ?? property,
-        required,
-      )?.value;
+      newInstance[property] =
+        interaction.options.get(name ?? property, required)?.value ||
+        originalInstance[property];
     });
 
-    return dtoInstance;
+    return newInstance;
+
   }
 }


### PR DESCRIPTION
#602

Switched the flow to modify a copy of the object instead of the original to preserve the original values and avoid future conflicts.
The value will default to the initially assigned value if one is present instead of the previous undefined.

Sample usage:
```typescript
export enum ResponseVisibility {
  Ephemeral,
  Public,
}

export class PingDTO {
  @Choice(ResponseVisibility)
  @Param({
    description: "Response visibility",
    required: false,
    type: ParamType.INTEGER,
  })
  visibility: ResponseVisibility = ResponseVisibility.Ephemeral;
}
```

The visibility will default to `Ephemeral` when the value is not provided within the discord slash command.