### PR TITLE
fix(TransformPipe): validations not applied

### DIFF
--- a/packages/common/src/pipe/transform.pipe.ts
+++ b/packages/common/src/pipe/transform.pipe.ts
@@ -20,7 +20,7 @@ export class TransformPipe implements DiscordPipeTransform {
     if (!metadata.metatype || !interaction || !interaction.isCommand()) return;
 
     const { dtoInstance: originalInstance } = metadata.commandNode;
-    const newInstance = Object.assign({}, originalInstance);
+    const newInstance = Object.assign(Object.create(Object.getPrototypeOf(originalInstance)), originalInstance);
 
     Object.keys(originalInstance).forEach((property: string) => {
       const paramDecoratorMetadata =


### PR DESCRIPTION
When using `Object.assign({}, originalInstance);`, you lose the type of the DTO, therefore losing the decorators required to make class-validator work.

This can be seen in the sample as well - the phone number is not validated.

`Object.assign(Object.create(Object.getPrototypeOf(originalInstance)), originalInstance);` creates a new object from the prototype of the origin instance, therefore keeping the original dto definitions.