### PR TITLE
feat: support context menu commands

### DIFF
--- a/packages/core/src/decorators/command/command-options.ts
+++ b/packages/core/src/decorators/command/command-options.ts
@@ -29,5 +29,5 @@ export interface CommandOptions {
   /**
    * Command Type (Slash or Context Menu)
    */
-  type: ApplicationCommandTypes;
+  type?: ApplicationCommandTypes;
 }

--- a/packages/core/src/decorators/command/command-options.ts
+++ b/packages/core/src/decorators/command/command-options.ts
@@ -1,3 +1,5 @@
+import { ApplicationCommandTypes } from 'discord.js/typings/enums';
+
 import { TInclude } from '../../definitions/types/include.type';
 
 /**
@@ -23,4 +25,9 @@ export interface CommandOptions {
    * Set default permission
    */
   defaultPermission?: boolean;
+
+  /**
+   * Command Type (Slash or Context Menu)
+   */
+  type: ApplicationCommandTypes;
 }

--- a/packages/core/src/definitions/interfaces/register-command-options.ts
+++ b/packages/core/src/definitions/interfaces/register-command-options.ts
@@ -1,5 +1,5 @@
 import {
-  ChatInputApplicationCommandData,
+  ApplicationCommandData,
   Message,
   Snowflake,
 } from 'discord.js';
@@ -15,7 +15,7 @@ export interface RegisterCommandOptions {
    */
   allowFactory?: (
     message: Message,
-    commandList: ChatInputApplicationCommandData[],
+    commandList: ApplicationCommandData[],
   ) => boolean;
 
   /**

--- a/packages/core/src/providers/discord-command.provider.ts
+++ b/packages/core/src/providers/discord-command.provider.ts
@@ -1,15 +1,15 @@
 import { Injectable } from '@nestjs/common';
-import { ChatInputApplicationCommandData } from 'discord.js';
+import { ApplicationCommandData } from 'discord.js';
 
 @Injectable()
 export class DiscordCommandProvider {
-  private readonly commandList: ChatInputApplicationCommandData[] = [];
+  private readonly commandList: ApplicationCommandData[] = [];
 
-  addCommand(command: ChatInputApplicationCommandData) {
+  addCommand(command: ApplicationCommandData) {
     this.commandList.push(command);
   }
 
-  getAllCommands(): ChatInputApplicationCommandData[] {
+  getAllCommands(): ApplicationCommandData[] {
     return this.commandList;
   }
 }

--- a/packages/core/src/services/build-application-command.service.ts
+++ b/packages/core/src/services/build-application-command.service.ts
@@ -7,7 +7,7 @@ import {
   ApplicationCommandOptionData,
   ApplicationCommandSubCommandData,
   ApplicationCommandSubGroupData,
-  ChatInputApplicationCommandData,
+  ApplicationCommandData,
 } from 'discord.js';
 import {
   ApplicationCommandOptionTypes,
@@ -42,24 +42,27 @@ export class BuildApplicationCommandService {
   async resolveCommandOptions(
     instance: DiscordCommand,
     methodName: string,
-    { name, description, include = [], defaultPermission }: CommandOptions,
-  ): Promise<ChatInputApplicationCommandData> {
+    { name, description, include = [], defaultPermission, type }: CommandOptions,
+  ): Promise<ApplicationCommandData> {
     this.paramResolver.resolve({ instance, methodName });
     const payloadType = this.paramResolver.getPayloadType({
       instance,
       methodName,
     });
     this.commandTreeService.appendNode([name], { instance });
-    const applicationCommandData: ChatInputApplicationCommandData = {
-      type: ApplicationCommandTypes.CHAT_INPUT,
+    const applicationCommandData: ApplicationCommandData = {
+      type,
       name,
       description,
       defaultPermission,
     };
-    applicationCommandData.options = await this.resolveSubCommandOptions(
-      name,
-      include,
-    );
+
+    if(applicationCommandData.type === ApplicationCommandTypes.CHAT_INPUT) {
+      applicationCommandData.options = await this.resolveSubCommandOptions(
+        name,
+        include,
+      );
+    }
 
     let dtoInstance: any;
     if (payloadType) {
@@ -86,9 +89,11 @@ export class BuildApplicationCommandService {
         });
       }
 
-      applicationCommandData.options = applicationCommandData.options.concat(
-        this.sortByRequired(commandOptions),
-      );
+      if(applicationCommandData.type === ApplicationCommandTypes.CHAT_INPUT) {
+        applicationCommandData.options = applicationCommandData.options.concat(
+          this.sortByRequired(commandOptions),
+        );
+      }
     }
 
     return applicationCommandData;

--- a/packages/core/src/services/build-application-command.service.ts
+++ b/packages/core/src/services/build-application-command.service.ts
@@ -42,7 +42,7 @@ export class BuildApplicationCommandService {
   async resolveCommandOptions(
     instance: DiscordCommand,
     methodName: string,
-    { name, description, include = [], defaultPermission, type }: CommandOptions,
+    { name, description, include = [], defaultPermission, type = ApplicationCommandTypes.CHAT_INPUT }: CommandOptions,
   ): Promise<ApplicationCommandData> {
     this.paramResolver.resolve({ instance, methodName });
     const payloadType = this.paramResolver.getPayloadType({


### PR DESCRIPTION
Hi!

I've been working with discord-nestjs for a little and realized it doesn't support context menu commands (user/message commands instead of chat actions). From my understanding of discord.js it should just be this easy fix, adding the type to the decorator!