### PR TITLE
Fix README global commands more info URL

### DIFF
--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -524,7 +524,7 @@ command registration setting. It works according to the following principle:
 
 The `allowFactory`, `forGuild` and `removeCommandsBefore` options are combined with each other.
 
-> Global commands, unlike guild commands, are cached and updated once per hour. [More info](https://discordjs.guide/interactions/registering-slash-commands.html#global-commands).
+> Global commands, unlike guild commands, are cached and updated once per hour. [More info](https://discordjs.guide/interactions/slash-commands.html#global-commands).
 
 #### 💡 Example
 


### PR DESCRIPTION
The URL for more info on global commands appears to have changed resulting in a 404 error. Updated this with the new URL.