### PR TITLE
fix: typos in prefix-command decorator

### DIFF
--- a/packages/core/src/decorators/prefix-command/prefix-command.decorator.ts
+++ b/packages/core/src/decorators/prefix-command/prefix-command.decorator.ts
@@ -4,7 +4,7 @@ import { ON_PREFIX_COMMAND_DECORATOR } from './prefix-command.constant';
 /**
  * On prefix command decorator
  *
- * Crate prefix command
+ * Create prefix command
  */
 export function PrefixCommand(
   name: string,


### PR DESCRIPTION
# Description

Fixed a documentation typo for the `@PrefixCommand()` decorator:

![image](https://user-images.githubusercontent.com/50140834/197206521-fd696234-d08a-4884-b2f4-6808e7b3de45.png)
