### PR TITLE
fix: modal 'fields' are undefined in some cases

### DIFF
--- a/packages/common/src/pipe/modal-fields-transform.pipe.ts
+++ b/packages/common/src/pipe/modal-fields-transform.pipe.ts
@@ -30,7 +30,7 @@ export class ModalFieldsTransformPipe implements DiscordPipeTransform {
     Object.keys(dtoInstance).forEach((property) => {
       const fieldCustomMetadata =
         this.metadataProvider.getFiledDecoratorMetadata(dtoInstance, property);
-      if (fieldCustomMetadata) {
+      if (fieldCustomMetadata && modal.fields) {
         plainObject[property] = modal.fields.getField(
           fieldCustomMetadata.customId ?? property,
           fieldCustomMetadata.type,
@@ -44,7 +44,7 @@ export class ModalFieldsTransformPipe implements DiscordPipeTransform {
           dtoInstance,
           property,
         );
-      if (textInputValueCustomMetadata) {
+      if (textInputValueCustomMetadata && modal.fields) {
         plainObject[property] = modal.fields.getTextInputValue(
           textInputValueCustomMetadata.customId ?? property,
         );


### PR DESCRIPTION
I've tested with the provided modal sample and it's broken (the modal don't open). With the fix everything is working again.