### PR TITLE
PoC: Only one event listener for all commands

### DIFF
--- a/packages/core/src/explorers/command/command.explorer.ts
+++ b/packages/core/src/explorers/command/command.explorer.ts
@@ -20,7 +20,7 @@ export class CommandExplorer implements ClassExplorer {
     private readonly buildApplicationCommandService: BuildApplicationCommandService,
     private readonly externalContextCreator: ExternalContextCreator,
     private readonly optionService: OptionService,
-  ) {}
+  ) { }
 
   private readonly discordParamFactory = new DiscordParamFactory();
   private readonly event: keyof ClientEvents = 'interactionCreate';
@@ -68,19 +68,10 @@ export class CommandExplorer implements ClassExplorer {
     groupName?: string,
   ): void {
     this.discordClientService
-      .getClient()
-      .on(
-        this.event,
+      .addCommandHandler(
+        commandName,
         async (...eventArgs: ClientEvents['interactionCreate']) => {
           const [interaction] = eventArgs;
-          if (
-            (!interaction.isChatInputCommand() &&
-              !interaction.isContextMenuCommand()) ||
-            interaction.commandName !== commandName
-          ) {
-            return;
-          }
-
           if (
             interaction.isChatInputCommand() &&
             ((groupName &&
@@ -96,8 +87,10 @@ export class CommandExplorer implements ClassExplorer {
               collectors: [],
             } as EventContext);
 
-            if (returnReply) {
+            if (returnReply && !interaction.isAutocomplete()) {
               await interaction.reply(returnReply);
+            }else if (returnReply && interaction.isAutocomplete()) {
+              await interaction.respond(returnReply);
             }
           } catch (exception) {
             if (


### PR DESCRIPTION
Currently for each command a new event listener is added, this is rather inconvenient as one easily reaches more than 10 handlers this way.

Having a map, that contains each command(Name, handler function), enables us to only use one event listener  for all commands.

Therefore I made this quick PoC, I'm open to discussion and suggestions :)

References: #1002 
