### PR TITLE
Added channel type to `@Param`

### DIFF
--- a/packages/core/src/decorators/option/param/non-param-options.ts
+++ b/packages/core/src/decorators/option/param/non-param-options.ts
@@ -10,5 +10,6 @@ export interface NonParamOptions extends BaseParamOptions {
     | ParamType.ROLE
     | ParamType.MENTIONABLE
     | ParamType.USER
-    | ParamType.ATTACHMENT;
+    | ParamType.ATTACHMENT
+    | ParamType.CHANNEL;
 }

--- a/packages/core/src/definitions/types/param.type.ts
+++ b/packages/core/src/definitions/types/param.type.ts
@@ -3,6 +3,7 @@ export enum ParamType {
   INTEGER,
   BOOLEAN,
   USER,
+  CHANNEL,
   ROLE,
   MENTIONABLE,
   NUMBER,

--- a/packages/core/src/explorers/option/option.explorer.ts
+++ b/packages/core/src/explorers/option/option.explorer.ts
@@ -99,6 +99,8 @@ export class OptionExplorer {
         return ApplicationCommandOptionType.User;
       case ParamType.ATTACHMENT:
         return ApplicationCommandOptionType.Attachment;
+      case ParamType.CHANNEL:
+        return ApplicationCommandOptionType.Channel;
       default: {
         const metatype = this.metadataProvider.getPropertyTypeMetadata(
           instance,


### PR DESCRIPTION
Currently, when creating params for a command, the `@Param`'s `type` field doesn't support the channel type, despite it being a possible option type with the official Discord API.

This pull request adds the `CHANNEL` type to `ParamType`, updates the `NonParamOption` type and added a case for it when converting to Discord API types.